### PR TITLE
Fix virtual host config for Nginx proxy

### DIFF
--- a/ansible/roles/nginx/templates/vhost-http.j2
+++ b/ansible/roles/nginx/templates/vhost-http.j2
@@ -1,9 +1,7 @@
 server {
     server_name {{ proxy_hostname }};
 
-    include snippets/ssl;
-
-    listen 443 ssl http2;
+    listen 80;
 
     location / {
         proxy_pass {{ proxy_upstream }};
@@ -12,18 +10,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Server ssl;
-        proxy_set_header HTTPS 1;
 
         proxy_send_timeout 300;
         proxy_read_timeout 300;
     }
-}
-
-server {
-    server_name {{ proxy_hostname }};
-
-    listen 80;
-
-    return 301 https://$host$request_uri;
 }

--- a/ansible/roles/shopware-dev/tasks/main.yml
+++ b/ansible/roles/shopware-dev/tasks/main.yml
@@ -70,7 +70,7 @@
         src: "ports.conf.j2"
         dest: "/etc/apache2/ports.conf"
   vars:
-    apache_port: "{{ 81 if proxy_ssl else 80 }}"
+    apache_port: "{{ 81 if proxy_enabled else 80 }}"
 
 - name: copy .psh.yaml.override file for shopware install
   template:


### PR DESCRIPTION
Currently `vagrant up` results in an error when `proxy_enables` is set to `yes` and `proxy_ssl` is set to `no`.
This is caused by two mistakes. First of all the vhost-http template and vhost-https template are identical. As a result, the nginx tries to load `snippets/ssl` even if ssl is disabled, which then can not be found.
Second, the Apache2 must listen on port 80 as soon as the Nginx is enabled, which is set by `proxy_enabled` rather than `proxy_ssl`.