### PR TITLE
Add proxy_http_version 1.1 to nginx vhost templates to prevent no-cac…

### DIFF
--- a/ansible/roles/nginx/templates/vhost-http.j2
+++ b/ansible/roles/nginx/templates/vhost-http.j2
@@ -6,6 +6,8 @@ server {
     location / {
         proxy_pass {{ proxy_upstream }};
 
+        proxy_http_version 1.1;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ansible/roles/nginx/templates/vhost-https.j2
+++ b/ansible/roles/nginx/templates/vhost-https.j2
@@ -8,6 +8,8 @@ server {
     location / {
         proxy_pass {{ proxy_upstream }};
 
+        proxy_http_version 1.1;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
…he headers

For reference: https://github.com/shopwareLabs/shopware-platform-vagrant/issues/14