### PR TITLE
Add task to remove platform folder

### DIFF
--- a/ansible/roles/shopware-dev/tasks/main.yml
+++ b/ansible/roles/shopware-dev/tasks/main.yml
@@ -5,6 +5,11 @@
     dest: /home/vagrant/shopware-dev
     clone: yes
 
+- name: delete platform folder
+  file:
+    path: /home/vagrant/shopware-dev/platform
+    state: absent
+  
 - name: clone shopware platform git repo
   git:
     repo: http://github.com/shopware/platform.git


### PR DESCRIPTION
The platform cloning task causes an error, because the folder already exists. 
The change https://github.com/shopware/development/commit/687c27e1071d90e1a680e0bd8b51c859ac3b9ec3 leads to that error, so we have to remove the folder before cloning the platform folder.

I added a new task to remove the folder, so the cloning of the platform repo is working correct.